### PR TITLE
Автотесты запускаются во всех режимах компиляции

### DIFF
--- a/autotests/run.bat
+++ b/autotests/run.bat
@@ -15,18 +15,27 @@ goto :EOF
 
 :RUN_TEST
 setlocal
+  set SRFLAGS=
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=-OP
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=-OR
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=--gen=direct
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=--gen=interp
   for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
 endlocal
 goto :EOF
 
 :RUN_TEST_AUX
 setlocal
-  echo Passing %1...
+  echo Passing %1 (flags %SRFLAGS%)...
   set SREF=%1
   set CPP=%~n1.cpp
   set EXE=%~n1.exe
 
-  ..\bin\srefc-core %1 2> __error.txt
+  ..\bin\srefc-core %SRFLAGS% %1 2> __error.txt
   if errorlevel 1 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
     exit
@@ -61,11 +70,11 @@ goto :EOF
 
 :RUN_TEST_AUX.BAD-SYNTAX
 setlocal
-  echo Passing %1 (syntax error recovering)...
+  echo Passing %1 (syntax error recovering, flags %SRFLAGS%)...
   set SREF=%1
   set CPP=%~n1.cpp
 
-  ..\bin\srefc-core %1 2> __error.txt
+  ..\bin\srefc-core %SRFLAGS% %1 2> __error.txt
   if errorlevel 100 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
     exit

--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 run_test_aux() {
-  echo Passing $1...
+  echo Passing $1 \(flags $SRFLAGS\)...
   SREF=$1
   CPP=${SREF%%.sref}.cpp
   EXE=${SREF%%.sref}
@@ -37,12 +37,12 @@ run_test_aux() {
 }
 
 run_test_aux.BAD-SYNTAX() {
-  echo Passing $1...
+  echo Passing $1 \(syntax error recovering, flags $SRFLAGS\)...
   SREF=$1
   CPP=${SREF%%.sref}.cpp
   EXE=${SREF%%.sref}
 
-  ../bin/srefc-core $SREF 2>__error.txt
+  ../bin/srefc-core $SRFLAGS $SREF 2>__error.txt
   if [ $? -ge 100 ]; then
     echo COMPILER ON $SREF FAILS, SEE __error.txt
     exit
@@ -61,7 +61,11 @@ run_test_aux.BAD-SYNTAX() {
 run_test() {
   SREF=$1
   SUFFIX=`echo ${SREF%%.sref} | sed 's/[^.]*\(\.[^.]*\)*/\1/'`
-  run_test_aux$SUFFIX $1
+  SRFLAGS= run_test_aux$SUFFIX $1
+  SRFLAGS=-OP run_test_aux$SUFFIX $1
+  SRFLAGS=-OR run_test_aux$SUFFIX $1
+  SRFLAGS=--gen=direct run_test_aux$SUFFIX $1
+  SRFLAGS=--gen=interp run_test_aux$SUFFIX $1
 }
 
 if [ -z "$1" ]; then

--- a/src/common/GetOpt-CheckRepeated.sref
+++ b/src/common/GetOpt-CheckRepeated.sref
@@ -1,0 +1,27 @@
+/**
+  <GetOpt-CheckRepeated (e.UniqueTags) (e.Errors) e.Options>
+    == (e.Errors) e.Options
+*/
+$ENTRY GetOpt-CheckRepeated {
+  // Разрешаем повторять опции с одинаковым значением
+  (e.CheckedTags-B s.Tag e.CheckedTags-E)
+  (e.Errors)
+  e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M (s.Tag s.Num2 e.Value) e.Opts-E =
+    <GetOpt-CheckRepeated
+      (e.CheckedTags-B s.Tag e.CheckedTags-E)
+      (e.Errors)
+      e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M e.Opts-E
+    >;
+
+  (e.CheckedTags-B s.Tag e.CheckedTags-E)
+  (e.Errors)
+  e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M (s.Tag s.Num2 e.Value2) e.Opts-E =
+    <GetOpt-CheckRepeated
+      (e.CheckedTags-B s.Tag e.CheckedTags-E)
+      (e.Errors (s.Num2 #RepeatOption s.Tag))
+      e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M e.Opts-E
+    >;
+
+  (e.CheckedTags) (e.Errors) e.Options =
+    (e.Errors) e.Options;
+}

--- a/src/compiler/HighLevelRASL-OptResult.sref
+++ b/src/compiler/HighLevelRASL-OptResult.sref
@@ -608,8 +608,19 @@ DoFreezeRanges-MakeSavers {
       <Map
         {
           /*
-            Все команды распознавания содержат номер скобок третьим термом,
-            общий формат (s.Command s.Direction s.BracketNum e.Info)
+            Сохраняющие команды сопоставления содержат номер скобок
+            четвёртым термом, их можно узнать по указателю направления
+            в третьем терме.
+          */
+          (s.Command^ s.ElemPos #AlgLeft s.Num e.Info^) =
+            (s.Command s.ElemPos #AlgLeft s.ContextTop e.Info);
+
+          (s.Command^ s.ElemPos #AlgRight s.Num e.Info^) =
+            (s.Command s.ElemPos #AlgRight s.ContextTop e.Info);
+
+          /*
+            Остальные команды распознавания содержат номер скобок третьим
+            термом, общий формат (s.Command s.Direction s.BracketNum e.Info)
           */
           (s.Command^ s.Direction^ s.Num e.Info^) =
             (s.Command s.Direction s.ContextTop e.Info);

--- a/src/compiler/ParseCmdLine.sref
+++ b/src/compiler/ParseCmdLine.sref
@@ -1,6 +1,9 @@
 //FROM GetOpt
 $EXTERN GetOpt;
 
+//FROM GetOpt-CheckRepeated
+$EXTERN GetOpt-CheckRepeated;
+
 //FROM LibraryEx
 $EXTERN Fetch, Seq, MapReduce, Map;
 
@@ -34,7 +37,7 @@ $ENTRY ParseCommandLine {
       <Seq
         {
           (e.Errors) e.Options =
-            <CheckRepeated
+            <GetOpt-CheckRepeated
               (#CppCompiler #GenMode #Opt #ErrorFile) (e.Errors) e.Options
             >;
         }
@@ -204,28 +207,4 @@ $ENTRY ParseCommandLine {
         }
       >
     >;
-}
-
-CheckRepeated {
-  // Разрешаем повторять опции с одинаковым значением
-  (e.CheckedTags-B s.Tag e.CheckedTags-E)
-  (e.Errors)
-  e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M (s.Tag s.Num2 e.Value) e.Opts-E =
-    <CheckRepeated
-      (e.CheckedTags-B s.Tag e.CheckedTags-E)
-      (e.Errors)
-      e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M e.Opts-E
-    >;
-
-  (e.CheckedTags-B s.Tag e.CheckedTags-E)
-  (e.Errors)
-  e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M (s.Tag s.Num2 e.Value2) e.Opts-E =
-    <CheckRepeated
-      (e.CheckedTags-B s.Tag e.CheckedTags-E)
-      (e.Errors (s.Num2 #RepeatOption s.Tag))
-      e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M e.Opts-E
-    >;
-
-  (e.CheckedTags) (e.Errors) e.Options =
-    (e.Errors) e.Options;
 }

--- a/src/lexgen/LexGen.sref
+++ b/src/lexgen/LexGen.sref
@@ -3,24 +3,86 @@
 */
 
 //FROM LibraryEx
-$EXTERN ArgList;
+$EXTERN ArgList, Fetch, Map;
+
+//FROM Library
+$EXTERN WriteLine, StrFromInt;
+
+//FROM Generator
+$EXTERN Generate-SelfUpdate, Generate-ToDifferent;
+
+//FROM GetOpt
+$EXTERN GetOpt;
 
 $ENTRY Go {
   = <Main <ArgList>>;
 }
 
-//FROM Library
-$EXTERN WriteLine;
-
-//FROM Generator
-$EXTERN Generate-SelfUpdate, Generate-ToDifferent;
-
 Main {
-  (e.ProgName) (e.File) =
-    <Generate-SelfUpdate e.File>;
+  (e.ProgName) e.Options =
+    <Main-CheckArgs
+      <GetOpt
+        (
+          (#From #Required 'f' ('from'))
+          (#To #Required 'o' ('to'))
+        )
+        e.Options
+      >
+    >;
+}
 
-  (e.ProgName) ('-from:' e.From) ('-to:' e.To) =
-    <Generate-ToDifferent (e.From) e.To>;
+Main-CheckArgs {
+  () (#FILE s.Pos e.FileName) =
+    <Generate-SelfUpdate e.FileName>;
 
-  (e.ProgName) e.Other = <WriteLine 'Command line error'>;
+  () e.Begin (#From s.PosFrom e.From) e.End =
+    <Fetch
+      e.Begin e.End {
+        (#To s.PosTo e.To) =
+          <Generate-ToDifferent (e.From) e.To>;
+
+        e.Other =
+          <FormatError s.PosFrom 'expected argument --to'>
+          <Help>;
+      }
+    >;
+
+  () e.Begin (#To s.Pos e.To) e.End =
+    <FormatError s.Pos 'exptected argument --from'>
+    <Help>;
+
+  () e.AnyOther =
+    <WriteLine 'Command line error: unrecognized command line'>
+    <Help>;
+
+  (e.Errors) e.AnyOther =
+    <Map
+      {
+        (s.Pos #NoRequiredParam e.Opt) =
+          <FormatError s.Pos 'option ' e.Opt ' expects parameter'>;
+
+        (s.Pos #UnknownShortOption s.Option) =
+          <FormatError s.Pos 'unknown option -' s.Option>;
+
+        (s.Pos #UnknownLongOption e.Option) =
+          <FormatError s.Pos 'unknown option --' e.Option>;
+      }
+      e.Errors
+    >
+    <Help>;
+}
+
+FormatError {
+  s.Pos e.Message =
+    <WriteLine 'Command line argument ' <StrFromInt s.Pos> ': ' e.Message>;
+}
+
+Help {
+  =
+    <WriteLine 'Use:'>
+    <WriteLine '    lexgen filename.sref - for rewritting file\n'>
+    <WriteLine '    lexgen --from=file1.sref --to=file2.sref - for writting '
+               'to other target\n'>
+    <WriteLine '    --from, -f - source file'>
+    <WriteLine '    --to, -o - target file'>;
 }

--- a/src/srmake/ParseCmdLine.sref
+++ b/src/srmake/ParseCmdLine.sref
@@ -1,99 +1,131 @@
+//FROM GetOpt
+$EXTERN GetOpt;
+
+//FROM GetOpt-CheckRepeated
+$EXTERN GetOpt-CheckRepeated;
+
+//FROM LibraryEx
+$EXTERN Fetch, Seq, MapReduce, Map;
+
 /**
   <ParseCommandLine e.Arguments>
-    == t.Compiler (e.Folders) t.FoundedFile*
-    == (#CmdLineError e.Message)
+    == #Success
+       (e.CppCompiler) (e.SrefCompiler) (e.FileName) (e.Flags) e.Folders
+    == #Fails (s.ArgNum e.Message)*
 
-  t.FoundedFile -- см. в FindFile
-  t.Compiler ::= (#NoCompile) | (#CompileCommand e.Command)
+  e.Folders ::= (s.FolderType e.Path)*
+  s.FolderType ::= #Search | #Runtime
 */
 $ENTRY ParseCommandLine {
   e.Arguments =
-    <DoParseCommandLine (/* files */) (/* folders */) e.Arguments>;
+    <Fetch
+      <GetOpt
+        (
+          (#CppCompiler #Required 'c' ('cpp-command'))
+          (#SrefCompiler #Required 's' ('sref-command'))
+          (#SearchFolder #Required 'd' ('dir') ('directory'))
+          (#RuntimeFolder #Required 'D' ('runtime-dir') ('runtime-directory'))
+          (#CompilerOption #Required 'X' ('thru') ('through'))
+        )
+        e.Arguments
+      >
+      <Seq
+        {
+          (e.Errors) e.Options =
+            <GetOpt-CheckRepeated
+              (#CppCompiler #SrefCompiler #FILE) (e.Errors) e.Options
+            >;
+        }
+        {
+          (e.Errors) e.Options-B (#CppCompiler s.Num e.Command) e.Options-E =
+            (e.Errors) ((e.Command)) e.Options-B e.Options-E;
+
+          (e.Errors) e.Options =
+            (e.Errors (1 #NoCppCompiler)) (()) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag)
+          e.Options-B (#SrefCompiler s.Num e.Command) e.Options-E =
+            (e.Errors) (e.Bag (e.Command)) e.Options-B e.Options-E;
+
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors) (e.Bag ('srefc-core')) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag)
+          e.Options-B (#FILE s.Num e.FileName) e.Options-E =
+            (e.Errors) (e.Bag (e.FileName)) e.Options-B e.Options-E;
+
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors (1 #NoSourceFile)) (e.Bag ()) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors)
+            <MapReduce
+              {
+                ((e.CppCompiler) (e.SrefCompiler) e.Bag^)
+                (#CompilerOption s.Num e.Flag) =
+                  ((e.CppCompiler) (e.SrefCompiler ' "' e.Flag '"') e.Bag);
+
+                (e.Bag^) t.OtherOption = (e.Bag) t.OtherOption;
+              }
+              (e.Bag) e.Options
+            >;
+        }
+        {
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors) (e.Bag)
+            <Map
+              {
+                (#SearchFolder s.Num e.Folder) = (#Search e.Folder);
+                (#RuntimeFolder s.Num e.Folder) = (#Runtime e.Folder);
+              }
+              e.Options
+            >;
+        }
+        {
+          () ((e.CppCompiler) (e.SrefCompiler) (e.MainSource)) e.Folders =
+            #Success (e.CppCompiler) (e.SrefCompiler) (e.MainSource) e.Folders;
+
+          (e.Errors) (e.Bag) e.Folders =
+            #Fails
+            <Map
+              {
+                (s.Pos #NoRequiredParam e.Param) =
+                  (s.Pos 'option ' e.Param ' expects parameter');
+
+                (s.Pos #UnknownShortOption s.Option) =
+                  (s.Pos 'unknown option -' s.Option);
+
+                (s.Pos #UnknownLongOption e.Option) =
+                  (s.Pos 'unknown option --' e.Option);
+
+                // У нас все опции с параметрами, не должно возникать
+                // (s.Pos #UnexpectedLongOptionParam (e.Option) e.Param) =
+
+                (s.Pos #RepeatOption s.Tag) =
+                  (
+                    s.Pos
+                    <Fetch
+                      s.Tag {
+                        #CppCompiler = 'option -c or --cpp-command';
+                        #SrefCompiler = 'option -s or --sref-command';
+                        #FILE = 'source filename';
+                      }
+                    >
+                    ' must appear one time'
+                  );
+
+                (s.Pos #NoCppCompiler) =
+                  (s.Pos 'option -c or --cpp-command not found');
+
+                (s.Pos #NoSourceFile) =
+                  (s.Pos 'expected source filename in command line');
+              }
+              e.Errors
+            >;
+        }
+      >
+    >;
 }
-
-DoParseCommandLine {
-  (e.ScannedFiles) (e.Folders) ('-c') (e.CompileCommand) e.Files =
-    <DoParseFileNames
-      (#CompileCommand e.CompileCommand) (e.ScannedFiles) (e.Folders) e.Files
-    >;
-
-  (e.ScannedFiles) (e.Folders) ('-c') =
-    (#CmdLineError 'After option ''-c'' expected C++ compiler command line');
-
-  (e.ScannedFiles) (e.Folders) ('-d') (e.Directory) e.Options =
-    <DoParseCommandLine
-      (e.ScannedFiles) (e.Folders (#Search e.Directory)) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) ('-d') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  (e.ScannedFiles) (e.Folders) ('-D') (e.Directory) e.Options =
-    <DoParseCommandLine
-      (e.ScannedFiles) (e.Folders (#Runtime e.Directory)) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) ('-D') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  (e.ScannedFiles) (e.Folders) ('--') e.Options =
-    <DoParseFileNamesOnly
-      (#NoCompile) (e.ScannedFiles) (e.Folders) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) (e.NextFileName) e.Options =
-    <DoParseCommandLine
-       (e.ScannedFiles (e.NextFileName)) (e.Folders) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) = (#NoCompile) (e.Folders) e.ScannedFiles;
-}
-
-DoParseFileNames {
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-c') (e.CompileCommand) e.Options =
-    (#CmdLineError 'Multiple declaration of C++ compiler command line');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-c') =
-    (#CmdLineError 'After option ''-c'' expected C++ compiler command line');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-d') (e.Directory) e.Options =
-    <DoParseFileNames
-      t.Compiler (e.ScannedFiles) (e.Folders (#Search e.Directory)) e.Options
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-d') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-D') (e.Directory) e.Options =
-    <DoParseFileNames
-      t.Compiler (e.ScannedFiles) (e.Folders (#Runtime e.Directory)) e.Options
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-D') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('--') e.Files =
-    <DoParseFileNamesOnly
-      t.Compiler (e.ScannedFiles) (e.Folders) e.Files
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) (e.NextFileName) e.Options =
-    <DoParseFileNames
-      t.Compiler (e.ScannedFiles (e.NextFileName)) (e.Folders) e.Options
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) =
-    t.Compiler (e.Folders) e.ScannedFiles;
-}
-
-DoParseFileNamesOnly {
-  t.Compiler (e.ScannedFiles) (e.Folders) (e.NextFileName) e.Files =
-    <DoParseFileNamesOnly
-      t.Compiler
-      (e.ScannedFiles (e.NextFileName)) e.Files
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) =
-    t.Compiler (e.Folders) e.ScannedFiles;
-}
-

--- a/src/srmake/SRMake.sref
+++ b/src/srmake/SRMake.sref
@@ -1,8 +1,8 @@
 //FROM Library
-$EXTERN WriteLine, System;
+$EXTERN WriteLine, System, StrFromInt, Exit;
 
 //FROM LibraryEx
-$EXTERN ArgList, Map, Fetch;
+$EXTERN ArgList, Map;
 
 //FROM FileScanner
 $EXTERN CreateFileList;
@@ -21,44 +21,14 @@ Main {
 
   (e.Program) e.Arguments =
     <MakeProject
-      <Fetch
-        <Get-s-option e.Arguments>
-        {
-          (e.SrefC) e.RestOfArguments =
-            (e.SrefC) <ParseCommandLine e.RestOfArguments>;
-        }
-      >
+      <ParseCommandLine e.Arguments>
     >;
-}
-
-/*
-  Да, костыль, но усложнение потребует большего объёма кода.
-  Костыль имеет недочёт: в командной строке может быть
-    srmake -c -s srefc g++ MainFile.sref
-  и эта строка корректно обработается.
-*/
-Get-s-option {
-  e.Arguments-B ('--') e.Arguments-E =
-    <Get-s-option e.Arguments-B> ('--') e.Arguments-E;
-
-  e.Arguments-B ('-s') (e.SrefC) e.Arguments-E =
-    (e.SrefC) e.Arguments-B e.Arguments-E;
-
-  e.Arguments = ('srefc') e.Arguments;
 }
 
 MakeProject {
-  (e.SrefC) (#CmdLineError e.Message) =
-    <WriteLine 'COMMAND LINE ERROR: ' e.Message>;
-
-  (e.SrefC) (#NoCompile) (e.Folders) (e.File) =
-    <WriteLine
-      'COMMAND LINE ERROR: Compiler not selected'
-    >;
-
-  (e.SrefC) (#CompileCommand e.Command) (e.Folders) (e.File) =
+  #Success (e.CppCompiler) (e.SrefCompiler) (e.SourceFile) e.Folders =
     <Make
-      (e.SrefC) (e.Command) (e.Folders)
+      (e.SrefCompiler) (e.CppCompiler) (e.Folders)
       <CreateFileList
         (
           <Map
@@ -68,46 +38,56 @@ MakeProject {
             e.Folders
           >
         )
-        e.File
+        e.SourceFile
       >
     >;
 
-  (e.SrefC) t.Compiler (e.Folders) e.ManyFiles =
-    <WriteLine
-      'COMMAND LINE ERROR: many files selected'
-    >;
+  #Fails e.Errors =
+    <Map
+      {
+        (s.Pos e.Message) =
+          <WriteLine
+            'Command line argument ' <StrFromInt s.Pos> ': ' e.Message
+          >;
+      }
+      e.Errors
+    >
+    <Exit 1>;
 }
 
 Make {
   (e.SrefC) (e.CompilerCommand) (e.Directories)
   e.Units-B (#NotFound e.UnitName) e.Units-E =
-    <Map PrintNotFound (#NotFound e.UnitName) e.Units-E>;
+    <Map
+      {
+        (#NotFound e.UnitName^) =
+          <WriteLine
+            'COMMAND LINE ERROR: Unit ' e.UnitName ' not found'
+          >;
+
+        (#Output e.Output) = ;
+        (#Source (e.Source) e.Output) = ;
+      }
+      (#NotFound e.UnitName) e.Units-E
+    >
+    <Exit 1>;
 
   (e.SrefC) (e.CompilerCommand) (e.Directories) e.Units =
     <System
-      e.SrefC ' -c "' e.CompilerCommand '" '
-      <Map PrintDirectory e.Directories>
-      <Map PrintUnit e.Units>
+      e.SrefC ' -c "' e.CompilerCommand '"'
+      <Map
+        {
+          (#Search e.Folder) = ' -d "' e.Folder '"';
+          (#Runtime e.Folder) = ' -D "' e.Folder '"';
+        }
+        e.Directories
+      >
+      <Map
+        {
+          (#Output e.Output) = ' "' e.Output '"';
+          (#Source (e.Source) e.Output) = ' "' e.Source '"';
+        }
+        e.Units
+      >
     >;
-}
-
-PrintNotFound {
-  (#NotFound e.UnitName) =
-    <WriteLine
-      'COMMAND LINE ERROR: Unit ' e.UnitName ' not found'
-    >;
-
-  (#Output e.Output) = ;
-  (#Source (e.Source) e.Output) = ;
-}
-
-PrintDirectory {
-  (#Search e.Folder) = '-d "' e.Folder '" ';
-
-  (#Runtime e.Folder) = '-D "' e.Folder '" ';
-}
-
-PrintUnit {
-  (#Output e.Output) = '"' e.Output '" ';
-  (#Source (e.Source) e.Output) = '"' e.Source '" ';
 }


### PR DESCRIPTION
Автотесты теперь выполняются дольше, поскольку компилируют с опциями: по умолчанию, `-OP`, `-OR`, `--gen=interp`, `--gen=direct`. Таким образом осуществляется более тщательная проверка компилятора.

Помимо этого обновился разбор аргументов командной строки в lexgen и srmake (вам это не интересно), также исправлена ошибка в оптимизаторе результатных выражений (это интересно Евгению). Придётся эти коммиты тоже влить, поскольку коммит с автотестами на самом верху.