### PR TITLE
Исправление ошибки в оптимизации результатов + автотесты для всех режимов

### DIFF
--- a/autotests/evar-loops-with-OR.sref
+++ b/autotests/evar-loops-with-OR.sref
@@ -1,0 +1,5 @@
+﻿MarkupArguments {
+  s.Num ('--' e.Arg '=' e.Param) e.Tail = ;
+}
+
+$ENTRY Go { = ; }

--- a/autotests/run.bat
+++ b/autotests/run.bat
@@ -15,18 +15,27 @@ goto :EOF
 
 :RUN_TEST
 setlocal
+  set SRFLAGS=
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=-OP
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=-OR
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=--gen=direct
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  set SRFLAGS=--gen=interp
   for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
 endlocal
 goto :EOF
 
 :RUN_TEST_AUX
 setlocal
-  echo Passing %1...
+  echo Passing %1 (flags %SRFLAGS%)...
   set SREF=%1
   set CPP=%~n1.cpp
   set EXE=%~n1.exe
 
-  ..\bin\srefc-core %1 2> __error.txt
+  ..\bin\srefc-core %SRFLAGS% %1 2> __error.txt
   if errorlevel 1 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
     exit
@@ -61,11 +70,11 @@ goto :EOF
 
 :RUN_TEST_AUX.BAD-SYNTAX
 setlocal
-  echo Passing %1 (syntax error recovering)...
+  echo Passing %1 (syntax error recovering, flags %SRFLAGS%)...
   set SREF=%1
   set CPP=%~n1.cpp
 
-  ..\bin\srefc-core %1 2> __error.txt
+  ..\bin\srefc-core %SRFLAGS% %1 2> __error.txt
   if errorlevel 100 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
     exit

--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 run_test_aux() {
-  echo Passing $1...
+  echo Passing $1 \(flags $SRFLAGS\)...
   SREF=$1
   CPP=${SREF%%.sref}.cpp
   EXE=${SREF%%.sref}
@@ -37,12 +37,12 @@ run_test_aux() {
 }
 
 run_test_aux.BAD-SYNTAX() {
-  echo Passing $1...
+  echo Passing $1 \(syntax error recovering, flags $SRFLAGS\)...
   SREF=$1
   CPP=${SREF%%.sref}.cpp
   EXE=${SREF%%.sref}
 
-  ../bin/srefc-core $SREF 2>__error.txt
+  ../bin/srefc-core $SRFLAGS $SREF 2>__error.txt
   if [ $? -ge 100 ]; then
     echo COMPILER ON $SREF FAILS, SEE __error.txt
     exit
@@ -61,7 +61,11 @@ run_test_aux.BAD-SYNTAX() {
 run_test() {
   SREF=$1
   SUFFIX=`echo ${SREF%%.sref} | sed 's/[^.]*\(\.[^.]*\)*/\1/'`
-  run_test_aux$SUFFIX $1
+  SRFLAGS= run_test_aux$SUFFIX $1
+  SRFLAGS=-OP run_test_aux$SUFFIX $1
+  SRFLAGS=-OR run_test_aux$SUFFIX $1
+  SRFLAGS=--gen=direct run_test_aux$SUFFIX $1
+  SRFLAGS=--gen=interp run_test_aux$SUFFIX $1
 }
 
 if [ -z "$1" ]; then

--- a/src/common/GetOpt-CheckRepeated.sref
+++ b/src/common/GetOpt-CheckRepeated.sref
@@ -1,0 +1,27 @@
+/**
+  <GetOpt-CheckRepeated (e.UniqueTags) (e.Errors) e.Options>
+    == (e.Errors) e.Options
+*/
+$ENTRY GetOpt-CheckRepeated {
+  // Разрешаем повторять опции с одинаковым значением
+  (e.CheckedTags-B s.Tag e.CheckedTags-E)
+  (e.Errors)
+  e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M (s.Tag s.Num2 e.Value) e.Opts-E =
+    <GetOpt-CheckRepeated
+      (e.CheckedTags-B s.Tag e.CheckedTags-E)
+      (e.Errors)
+      e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M e.Opts-E
+    >;
+
+  (e.CheckedTags-B s.Tag e.CheckedTags-E)
+  (e.Errors)
+  e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M (s.Tag s.Num2 e.Value2) e.Opts-E =
+    <GetOpt-CheckRepeated
+      (e.CheckedTags-B s.Tag e.CheckedTags-E)
+      (e.Errors (s.Num2 #RepeatOption s.Tag))
+      e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M e.Opts-E
+    >;
+
+  (e.CheckedTags) (e.Errors) e.Options =
+    (e.Errors) e.Options;
+}

--- a/src/compiler/Generator.sref
+++ b/src/compiler/Generator.sref
@@ -217,7 +217,7 @@ GenCommand {
     <PrintMatchChar (e.Indent) s.Direction s.BracketNumber s.Char>
     ;
 
-  (e.Indent) (#CmdCharSave s.Offset s.Direction s.BracketNumber s.Char) =
+  (e.Indent) (#CmdCharSave s.Direction s.BracketNumber s.Offset s.Char) =
     (e.Indent)
     <PrintMatchCharSave (e.Indent) s.Offset s.Direction s.BracketNumber s.Char>
     ;

--- a/src/compiler/HighLevelRASL-OptResult.sref
+++ b/src/compiler/HighLevelRASL-OptResult.sref
@@ -608,8 +608,19 @@ DoFreezeRanges-MakeSavers {
       <Map
         {
           /*
-            Все команды распознавания содержат номер скобок третьим термом,
-            общий формат (s.Command s.Direction s.BracketNum e.Info)
+            Сохраняющие команды сопоставления содержат номер скобок
+            четвёртым термом, их можно узнать по указателю направления
+            в третьем терме.
+          */
+          (s.Command^ s.ElemPos #AlgLeft s.Num e.Info^) =
+            (s.Command s.ElemPos #AlgLeft s.ContextTop e.Info);
+
+          (s.Command^ s.ElemPos #AlgRight s.Num e.Info^) =
+            (s.Command s.ElemPos #AlgRight s.ContextTop e.Info);
+
+          /*
+            Остальные команды распознавания содержат номер скобок третьим
+            термом, общий формат (s.Command s.Direction s.BracketNum e.Info)
           */
           (s.Command^ s.Direction^ s.Num e.Info^) =
             (s.Command s.Direction s.ContextTop e.Info);

--- a/src/compiler/HighLevelRASL-OptResult.sref
+++ b/src/compiler/HighLevelRASL-OptResult.sref
@@ -264,7 +264,7 @@ DoGenPattern {
       e.Ranges-B
       (#Junk e.Junk (#TkChar s.Char s.ContextOffset)) (#Range s.Num e.Range)
       e.Ranges-E
-      (e.Vars) (e.Commands (#CmdCharSave s.ContextOffset #AlgLeft s.Num s.Char))
+      (e.Vars) (e.Commands (#CmdCharSave #AlgLeft s.Num s.ContextOffset s.Char))
     >;
 
   s.ContextOffset
@@ -310,7 +310,7 @@ DoGenPattern {
       e.Ranges-B
       (#Range s.Num e.Range) (#Junk (#TkChar s.Char s.ContextOffset) e.Junk)
       e.Ranges-E
-      (e.Vars) (e.Commands (#CmdCharSave s.ContextOffset #AlgRight s.Num s.Char))
+      (e.Vars) (e.Commands (#CmdCharSave #AlgRight s.Num s.ContextOffset s.Char))
     >;
 
   s.ContextOffset

--- a/src/compiler/HighLevelRASL-OptResult.sref
+++ b/src/compiler/HighLevelRASL-OptResult.sref
@@ -608,19 +608,8 @@ DoFreezeRanges-MakeSavers {
       <Map
         {
           /*
-            Сохраняющие команды сопоставления содержат номер скобок
-            четвёртым термом, их можно узнать по указателю направления
-            в третьем терме.
-          */
-          (s.Command^ s.ElemPos #AlgLeft s.Num e.Info^) =
-            (s.Command s.ElemPos #AlgLeft s.ContextTop e.Info);
-
-          (s.Command^ s.ElemPos #AlgRight s.Num e.Info^) =
-            (s.Command s.ElemPos #AlgRight s.ContextTop e.Info);
-
-          /*
-            Остальные команды распознавания содержат номер скобок третьим
-            термом, общий формат (s.Command s.Direction s.BracketNum e.Info)
+            Все команды распознавания содержат номер скобок третьим термом,
+            общий формат (s.Command s.Direction s.BracketNum e.Info)
           */
           (s.Command^ s.Direction^ s.Num e.Info^) =
             (s.Command s.Direction s.ContextTop e.Info);

--- a/src/compiler/ParseCmdLine.sref
+++ b/src/compiler/ParseCmdLine.sref
@@ -1,6 +1,9 @@
 //FROM GetOpt
 $EXTERN GetOpt;
 
+//FROM GetOpt-CheckRepeated
+$EXTERN GetOpt-CheckRepeated;
+
 //FROM LibraryEx
 $EXTERN Fetch, Seq, MapReduce, Map;
 
@@ -34,7 +37,7 @@ $ENTRY ParseCommandLine {
       <Seq
         {
           (e.Errors) e.Options =
-            <CheckRepeated
+            <GetOpt-CheckRepeated
               (#CppCompiler #GenMode #Opt #ErrorFile) (e.Errors) e.Options
             >;
         }
@@ -204,28 +207,4 @@ $ENTRY ParseCommandLine {
         }
       >
     >;
-}
-
-CheckRepeated {
-  // Разрешаем повторять опции с одинаковым значением
-  (e.CheckedTags-B s.Tag e.CheckedTags-E)
-  (e.Errors)
-  e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M (s.Tag s.Num2 e.Value) e.Opts-E =
-    <CheckRepeated
-      (e.CheckedTags-B s.Tag e.CheckedTags-E)
-      (e.Errors)
-      e.Opts-B (s.Tag s.Num1 e.Value) e.Opts-M e.Opts-E
-    >;
-
-  (e.CheckedTags-B s.Tag e.CheckedTags-E)
-  (e.Errors)
-  e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M (s.Tag s.Num2 e.Value2) e.Opts-E =
-    <CheckRepeated
-      (e.CheckedTags-B s.Tag e.CheckedTags-E)
-      (e.Errors (s.Num2 #RepeatOption s.Tag))
-      e.Opts-B (s.Tag s.Num1 e.Value1) e.Opts-M e.Opts-E
-    >;
-
-  (e.CheckedTags) (e.Errors) e.Options =
-    (e.Errors) e.Options;
 }

--- a/src/compiler/ParseCmdLine.sref
+++ b/src/compiler/ParseCmdLine.sref
@@ -25,6 +25,9 @@ $ENTRY ParseCommandLine {
           (#Opt #Required 'O')
           (#ErrorFile #Required 'e' ('error-file'))
           (#SearchFolder #Required 'd' ('dir') ('directory'))
+          (#CppFlags #Required 'CF' ('cppflags'))
+          (#CppFlag #Required 'f' ('cppflag'))
+          (#RuntimeFolder #Required 'D' ('runtime-dir') ('runtime-directory'))
         )
         e.Arguments
       >
@@ -81,6 +84,57 @@ $ENTRY ParseCommandLine {
 
           (e.Errors) (e.Bag) e.Options =
             (e.Errors) (e.Bag #NoErrorFile) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag) e.Options =
+            ((e.Errors) (e.Bag)) e.Options;
+        }
+        (MapReduce {
+          ((e.Errors) (#NoCppCompiler e.Bag)) (#CppFlags s.Num e.Flags) =
+            (
+              (e.Errors (s.Num #FlagsForNoCompiler))
+              (#NoCppCompiler e.Bag)
+            );
+
+          ((e.Errors) (#NoCppCompiler e.Bag)) (#CppFlag s.Num e.Flag) =
+            (
+              (e.Errors (s.Num #FlagsForNoCompiler))
+              (#NoCppCompiler e.Bag)
+            );
+
+          ((e.Errors) ((e.CppCompiler) e.Bag)) (#CppFlags s.Num e.Flags) =
+            (
+              (e.Errors)
+              ((e.CppCompiler ' ' e.Flags) e.Bag)
+            );
+
+          ((e.Errors) ((e.CppCompiler) e.Bag)) (#CppFlag s.Num e.Flag) =
+            (
+              (e.Errors)
+              ((e.CppCompiler ' "' e.Flag '"') e.Bag)
+            );
+
+          ((e.Errors) (t.CppCompiler e.Bag)) (#RuntimeFolder s.Num e.Folder) =
+            (
+              (e.Errors)
+              (
+                <Fetch
+                  t.CppCompiler {
+                    #NoCppCompiler = #NoCppCompiler;
+                    (e.CppCompiler^) = (e.CppCompiler ' -I"' e.Folder '"');
+                  }
+                >
+                e.Bag
+              )
+            )
+            (#SearchFolder s.Num e.Folder);
+
+          ((e.Errors) (e.Bag)) t.OtherOption =
+            ((e.Errors) (e.Bag)) t.OtherOption;
+        })
+        {
+          ((e.Errors) (e.Bag)) e.Options =
+            (e.Errors) (e.Bag) e.Options;
         }
         {
           (e.Errors) (e.Bag) e.Options =

--- a/src/lexgen/LexGen.sref
+++ b/src/lexgen/LexGen.sref
@@ -3,24 +3,86 @@
 */
 
 //FROM LibraryEx
-$EXTERN ArgList;
+$EXTERN ArgList, Fetch, Map;
+
+//FROM Library
+$EXTERN WriteLine, StrFromInt;
+
+//FROM Generator
+$EXTERN Generate-SelfUpdate, Generate-ToDifferent;
+
+//FROM GetOpt
+$EXTERN GetOpt;
 
 $ENTRY Go {
   = <Main <ArgList>>;
 }
 
-//FROM Library
-$EXTERN WriteLine;
-
-//FROM Generator
-$EXTERN Generate-SelfUpdate, Generate-ToDifferent;
-
 Main {
-  (e.ProgName) (e.File) =
-    <Generate-SelfUpdate e.File>;
+  (e.ProgName) e.Options =
+    <Main-CheckArgs
+      <GetOpt
+        (
+          (#From #Required 'f' ('from'))
+          (#To #Required 'o' ('to'))
+        )
+        e.Options
+      >
+    >;
+}
 
-  (e.ProgName) ('-from:' e.From) ('-to:' e.To) =
-    <Generate-ToDifferent (e.From) e.To>;
+Main-CheckArgs {
+  () (#FILE s.Pos e.FileName) =
+    <Generate-SelfUpdate e.FileName>;
 
-  (e.ProgName) e.Other = <WriteLine 'Command line error'>;
+  () e.Begin (#From s.PosFrom e.From) e.End =
+    <Fetch
+      e.Begin e.End {
+        (#To s.PosTo e.To) =
+          <Generate-ToDifferent (e.From) e.To>;
+
+        e.Other =
+          <FormatError s.PosFrom 'expected argument --to'>
+          <Help>;
+      }
+    >;
+
+  () e.Begin (#To s.Pos e.To) e.End =
+    <FormatError s.Pos 'exptected argument --from'>
+    <Help>;
+
+  () e.AnyOther =
+    <WriteLine 'Command line error: unrecognized command line'>
+    <Help>;
+
+  (e.Errors) e.AnyOther =
+    <Map
+      {
+        (s.Pos #NoRequiredParam e.Opt) =
+          <FormatError s.Pos 'option ' e.Opt ' expects parameter'>;
+
+        (s.Pos #UnknownShortOption s.Option) =
+          <FormatError s.Pos 'unknown option -' s.Option>;
+
+        (s.Pos #UnknownLongOption e.Option) =
+          <FormatError s.Pos 'unknown option --' e.Option>;
+      }
+      e.Errors
+    >
+    <Help>;
+}
+
+FormatError {
+  s.Pos e.Message =
+    <WriteLine 'Command line argument ' <StrFromInt s.Pos> ': ' e.Message>;
+}
+
+Help {
+  =
+    <WriteLine 'Use:'>
+    <WriteLine '    lexgen filename.sref - for rewritting file\n'>
+    <WriteLine '    lexgen --from=file1.sref --to=file2.sref - for writting '
+               'to other target\n'>
+    <WriteLine '    --from, -f - source file'>
+    <WriteLine '    --to, -o - target file'>;
 }

--- a/src/make.bat
+++ b/src/make.bat
@@ -17,7 +17,7 @@ setlocal
   set DIR=%1
   set TARGET=%2
   set MAINSRC=%~n3
-  set CPPLINE_FLAGS=%4
+  set CPPLINE_FLAGS=%~4
   set PATH_TO_SREFC=%5
   if {%PATH_TO_SREFC%}=={} (
     set PATH_TO_SREFC=..\..

--- a/src/scripts/srefc.bat
+++ b/src/scripts/srefc.bat
@@ -15,5 +15,5 @@ set LIBDIR=%DISTRDIR%\srlib
 setlocal
   call "%DISTRDIR%\c-plus-plus.conf.bat"
   set PATH=%BINDIR%;%PATH%
-  srefc-core -c "%CPPLINE% %CPPLINE_FLAGS% -I\"%LIBDIR%\"" %* -d "%LIBDIR%"
+  srefc-core -c "%CPPLINE% %CPPLINE_FLAGS%" %* -D "%LIBDIR%"
 endlocal

--- a/src/scripts/srmake.bat
+++ b/src/scripts/srmake.bat
@@ -4,7 +4,7 @@
 set BINDIR=%~dp0
 set BINDIR=%BINDIR:~0,-1%
 
-:: Получаем путь к дистрибутиву, удаяем концевой \
+:: Получаем путь к дистрибутиву, удаляем концевой \
 for %%d in ("%BINDIR%") do set DISTRDIR=%%~dpd
 set DISTRDIR=%DISTRDIR:~0,-1%
 

--- a/src/scripts/srmake.bat
+++ b/src/scripts/srmake.bat
@@ -17,6 +17,6 @@ setlocal
   set PATH=%BINDIR%;%PATH%
   srmake-core ^
     -s srefc-core.exe ^
-    -c "%CPPLINE% %CPPLINE_FLAGS% -I\\"%LIBDIR%\\"" ^
-    %* -d "%LIBDIR%"
+    -c "%CPPLINE% %CPPLINE_FLAGS%" ^
+    %* -D "%LIBDIR%"
 endlocal

--- a/src/srmake/ParseCmdLine.sref
+++ b/src/srmake/ParseCmdLine.sref
@@ -22,10 +22,18 @@ DoParseCommandLine {
 
   (e.ScannedFiles) (e.Folders) ('-d') (e.Directory) e.Options =
     <DoParseCommandLine
-      (e.ScannedFiles) (e.Folders (e.Directory)) e.Options
+      (e.ScannedFiles) (e.Folders (#Search e.Directory)) e.Options
     >;
 
   (e.ScannedFiles) (e.Folders) ('-d') =
+    (#CmdLineError 'After option ''-d'' expected find directory');
+
+  (e.ScannedFiles) (e.Folders) ('-D') (e.Directory) e.Options =
+    <DoParseCommandLine
+      (e.ScannedFiles) (e.Folders (#Runtime e.Directory)) e.Options
+    >;
+
+  (e.ScannedFiles) (e.Folders) ('-D') =
     (#CmdLineError 'After option ''-d'' expected find directory');
 
   (e.ScannedFiles) (e.Folders) ('--') e.Options =
@@ -50,10 +58,18 @@ DoParseFileNames {
 
   t.Compiler (e.ScannedFiles) (e.Folders) ('-d') (e.Directory) e.Options =
     <DoParseFileNames
-      t.Compiler (e.ScannedFiles) (e.Folders (e.Directory)) e.Options
+      t.Compiler (e.ScannedFiles) (e.Folders (#Search e.Directory)) e.Options
     >;
 
   t.Compiler (e.ScannedFiles) (e.Folders) ('-d') =
+    (#CmdLineError 'After option ''-d'' expected find directory');
+
+  t.Compiler (e.ScannedFiles) (e.Folders) ('-D') (e.Directory) e.Options =
+    <DoParseFileNames
+      t.Compiler (e.ScannedFiles) (e.Folders (#Runtime e.Directory)) e.Options
+    >;
+
+  t.Compiler (e.ScannedFiles) (e.Folders) ('-D') =
     (#CmdLineError 'After option ''-d'' expected find directory');
 
   t.Compiler (e.ScannedFiles) (e.Folders) ('--') e.Files =

--- a/src/srmake/ParseCmdLine.sref
+++ b/src/srmake/ParseCmdLine.sref
@@ -1,99 +1,131 @@
+//FROM GetOpt
+$EXTERN GetOpt;
+
+//FROM GetOpt-CheckRepeated
+$EXTERN GetOpt-CheckRepeated;
+
+//FROM LibraryEx
+$EXTERN Fetch, Seq, MapReduce, Map;
+
 /**
   <ParseCommandLine e.Arguments>
-    == t.Compiler (e.Folders) t.FoundedFile*
-    == (#CmdLineError e.Message)
+    == #Success
+       (e.CppCompiler) (e.SrefCompiler) (e.FileName) (e.Flags) e.Folders
+    == #Fails (s.ArgNum e.Message)*
 
-  t.FoundedFile -- см. в FindFile
-  t.Compiler ::= (#NoCompile) | (#CompileCommand e.Command)
+  e.Folders ::= (s.FolderType e.Path)*
+  s.FolderType ::= #Search | #Runtime
 */
 $ENTRY ParseCommandLine {
   e.Arguments =
-    <DoParseCommandLine (/* files */) (/* folders */) e.Arguments>;
+    <Fetch
+      <GetOpt
+        (
+          (#CppCompiler #Required 'c' ('cpp-command'))
+          (#SrefCompiler #Required 's' ('sref-command'))
+          (#SearchFolder #Required 'd' ('dir') ('directory'))
+          (#RuntimeFolder #Required 'D' ('runtime-dir') ('runtime-directory'))
+          (#CompilerOption #Required 'X' ('thru') ('through'))
+        )
+        e.Arguments
+      >
+      <Seq
+        {
+          (e.Errors) e.Options =
+            <GetOpt-CheckRepeated
+              (#CppCompiler #SrefCompiler #FILE) (e.Errors) e.Options
+            >;
+        }
+        {
+          (e.Errors) e.Options-B (#CppCompiler s.Num e.Command) e.Options-E =
+            (e.Errors) ((e.Command)) e.Options-B e.Options-E;
+
+          (e.Errors) e.Options =
+            (e.Errors (1 #NoCppCompiler)) (()) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag)
+          e.Options-B (#SrefCompiler s.Num e.Command) e.Options-E =
+            (e.Errors) (e.Bag (e.Command)) e.Options-B e.Options-E;
+
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors) (e.Bag ('srefc-core')) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag)
+          e.Options-B (#FILE s.Num e.FileName) e.Options-E =
+            (e.Errors) (e.Bag (e.FileName)) e.Options-B e.Options-E;
+
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors (1 #NoSourceFile)) (e.Bag ()) e.Options;
+        }
+        {
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors)
+            <MapReduce
+              {
+                ((e.CppCompiler) (e.SrefCompiler) e.Bag^)
+                (#CompilerOption s.Num e.Flag) =
+                  ((e.CppCompiler) (e.SrefCompiler ' "' e.Flag '"') e.Bag);
+
+                (e.Bag^) t.OtherOption = (e.Bag) t.OtherOption;
+              }
+              (e.Bag) e.Options
+            >;
+        }
+        {
+          (e.Errors) (e.Bag) e.Options =
+            (e.Errors) (e.Bag)
+            <Map
+              {
+                (#SearchFolder s.Num e.Folder) = (#Search e.Folder);
+                (#RuntimeFolder s.Num e.Folder) = (#Runtime e.Folder);
+              }
+              e.Options
+            >;
+        }
+        {
+          () ((e.CppCompiler) (e.SrefCompiler) (e.MainSource)) e.Folders =
+            #Success (e.CppCompiler) (e.SrefCompiler) (e.MainSource) e.Folders;
+
+          (e.Errors) (e.Bag) e.Folders =
+            #Fails
+            <Map
+              {
+                (s.Pos #NoRequiredParam e.Param) =
+                  (s.Pos 'option ' e.Param ' expects parameter');
+
+                (s.Pos #UnknownShortOption s.Option) =
+                  (s.Pos 'unknown option -' s.Option);
+
+                (s.Pos #UnknownLongOption e.Option) =
+                  (s.Pos 'unknown option --' e.Option);
+
+                // У нас все опции с параметрами, не должно возникать
+                // (s.Pos #UnexpectedLongOptionParam (e.Option) e.Param) =
+
+                (s.Pos #RepeatOption s.Tag) =
+                  (
+                    s.Pos
+                    <Fetch
+                      s.Tag {
+                        #CppCompiler = 'option -c or --cpp-command';
+                        #SrefCompiler = 'option -s or --sref-command';
+                        #FILE = 'source filename';
+                      }
+                    >
+                    ' must appear one time'
+                  );
+
+                (s.Pos #NoCppCompiler) =
+                  (s.Pos 'option -c or --cpp-command not found');
+
+                (s.Pos #NoSourceFile) =
+                  (s.Pos 'expected source filename in command line');
+              }
+              e.Errors
+            >;
+        }
+      >
+    >;
 }
-
-DoParseCommandLine {
-  (e.ScannedFiles) (e.Folders) ('-c') (e.CompileCommand) e.Files =
-    <DoParseFileNames
-      (#CompileCommand e.CompileCommand) (e.ScannedFiles) (e.Folders) e.Files
-    >;
-
-  (e.ScannedFiles) (e.Folders) ('-c') =
-    (#CmdLineError 'After option ''-c'' expected C++ compiler command line');
-
-  (e.ScannedFiles) (e.Folders) ('-d') (e.Directory) e.Options =
-    <DoParseCommandLine
-      (e.ScannedFiles) (e.Folders (#Search e.Directory)) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) ('-d') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  (e.ScannedFiles) (e.Folders) ('-D') (e.Directory) e.Options =
-    <DoParseCommandLine
-      (e.ScannedFiles) (e.Folders (#Runtime e.Directory)) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) ('-D') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  (e.ScannedFiles) (e.Folders) ('--') e.Options =
-    <DoParseFileNamesOnly
-      (#NoCompile) (e.ScannedFiles) (e.Folders) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) (e.NextFileName) e.Options =
-    <DoParseCommandLine
-       (e.ScannedFiles (e.NextFileName)) (e.Folders) e.Options
-    >;
-
-  (e.ScannedFiles) (e.Folders) = (#NoCompile) (e.Folders) e.ScannedFiles;
-}
-
-DoParseFileNames {
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-c') (e.CompileCommand) e.Options =
-    (#CmdLineError 'Multiple declaration of C++ compiler command line');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-c') =
-    (#CmdLineError 'After option ''-c'' expected C++ compiler command line');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-d') (e.Directory) e.Options =
-    <DoParseFileNames
-      t.Compiler (e.ScannedFiles) (e.Folders (#Search e.Directory)) e.Options
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-d') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-D') (e.Directory) e.Options =
-    <DoParseFileNames
-      t.Compiler (e.ScannedFiles) (e.Folders (#Runtime e.Directory)) e.Options
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('-D') =
-    (#CmdLineError 'After option ''-d'' expected find directory');
-
-  t.Compiler (e.ScannedFiles) (e.Folders) ('--') e.Files =
-    <DoParseFileNamesOnly
-      t.Compiler (e.ScannedFiles) (e.Folders) e.Files
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) (e.NextFileName) e.Options =
-    <DoParseFileNames
-      t.Compiler (e.ScannedFiles (e.NextFileName)) (e.Folders) e.Options
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) =
-    t.Compiler (e.Folders) e.ScannedFiles;
-}
-
-DoParseFileNamesOnly {
-  t.Compiler (e.ScannedFiles) (e.Folders) (e.NextFileName) e.Files =
-    <DoParseFileNamesOnly
-      t.Compiler
-      (e.ScannedFiles (e.NextFileName)) e.Files
-    >;
-
-  t.Compiler (e.ScannedFiles) (e.Folders) =
-    t.Compiler (e.Folders) e.ScannedFiles;
-}
-

--- a/src/srmake/SRMake.sref
+++ b/src/srmake/SRMake.sref
@@ -58,7 +58,18 @@ MakeProject {
 
   (e.SrefC) (#CompileCommand e.Command) (e.Folders) (e.File) =
     <Make
-      (e.SrefC) (e.Command) (e.Folders) <CreateFileList (e.Folders) e.File>
+      (e.SrefC) (e.Command) (e.Folders)
+      <CreateFileList
+        (
+          <Map
+            {
+              (s.FolderTag e.Folder) = (e.Folder);
+            }
+            e.Folders
+          >
+        )
+        e.File
+      >
     >;
 
   (e.SrefC) t.Compiler (e.Folders) e.ManyFiles =
@@ -91,7 +102,9 @@ PrintNotFound {
 }
 
 PrintDirectory {
-  (e.Folder) = '-d "' e.Folder '" ';
+  (#Search e.Folder) = '-d "' e.Folder '" ';
+
+  (#Runtime e.Folder) = '-D "' e.Folder '" ';
 }
 
 PrintUnit {

--- a/src/srmake/SRMake.sref
+++ b/src/srmake/SRMake.sref
@@ -1,8 +1,8 @@
 //FROM Library
-$EXTERN WriteLine, System;
+$EXTERN WriteLine, System, StrFromInt, Exit;
 
 //FROM LibraryEx
-$EXTERN ArgList, Map, Fetch;
+$EXTERN ArgList, Map;
 
 //FROM FileScanner
 $EXTERN CreateFileList;
@@ -21,44 +21,14 @@ Main {
 
   (e.Program) e.Arguments =
     <MakeProject
-      <Fetch
-        <Get-s-option e.Arguments>
-        {
-          (e.SrefC) e.RestOfArguments =
-            (e.SrefC) <ParseCommandLine e.RestOfArguments>;
-        }
-      >
+      <ParseCommandLine e.Arguments>
     >;
-}
-
-/*
-  Да, костыль, но усложнение потребует большего объёма кода.
-  Костыль имеет недочёт: в командной строке может быть
-    srmake -c -s srefc g++ MainFile.sref
-  и эта строка корректно обработается.
-*/
-Get-s-option {
-  e.Arguments-B ('--') e.Arguments-E =
-    <Get-s-option e.Arguments-B> ('--') e.Arguments-E;
-
-  e.Arguments-B ('-s') (e.SrefC) e.Arguments-E =
-    (e.SrefC) e.Arguments-B e.Arguments-E;
-
-  e.Arguments = ('srefc') e.Arguments;
 }
 
 MakeProject {
-  (e.SrefC) (#CmdLineError e.Message) =
-    <WriteLine 'COMMAND LINE ERROR: ' e.Message>;
-
-  (e.SrefC) (#NoCompile) (e.Folders) (e.File) =
-    <WriteLine
-      'COMMAND LINE ERROR: Compiler not selected'
-    >;
-
-  (e.SrefC) (#CompileCommand e.Command) (e.Folders) (e.File) =
+  #Success (e.CppCompiler) (e.SrefCompiler) (e.SourceFile) e.Folders =
     <Make
-      (e.SrefC) (e.Command) (e.Folders)
+      (e.SrefCompiler) (e.CppCompiler) (e.Folders)
       <CreateFileList
         (
           <Map
@@ -68,46 +38,56 @@ MakeProject {
             e.Folders
           >
         )
-        e.File
+        e.SourceFile
       >
     >;
 
-  (e.SrefC) t.Compiler (e.Folders) e.ManyFiles =
-    <WriteLine
-      'COMMAND LINE ERROR: many files selected'
-    >;
+  #Fails e.Errors =
+    <Map
+      {
+        (s.Pos e.Message) =
+          <WriteLine
+            'Command line argument ' <StrFromInt s.Pos> ': ' e.Message
+          >;
+      }
+      e.Errors
+    >
+    <Exit 1>;
 }
 
 Make {
   (e.SrefC) (e.CompilerCommand) (e.Directories)
   e.Units-B (#NotFound e.UnitName) e.Units-E =
-    <Map PrintNotFound (#NotFound e.UnitName) e.Units-E>;
+    <Map
+      {
+        (#NotFound e.UnitName^) =
+          <WriteLine
+            'COMMAND LINE ERROR: Unit ' e.UnitName ' not found'
+          >;
+
+        (#Output e.Output) = ;
+        (#Source (e.Source) e.Output) = ;
+      }
+      (#NotFound e.UnitName) e.Units-E
+    >
+    <Exit 1>;
 
   (e.SrefC) (e.CompilerCommand) (e.Directories) e.Units =
     <System
-      e.SrefC ' -c "' e.CompilerCommand '" '
-      <Map PrintDirectory e.Directories>
-      <Map PrintUnit e.Units>
+      e.SrefC ' -c "' e.CompilerCommand '"'
+      <Map
+        {
+          (#Search e.Folder) = ' -d "' e.Folder '"';
+          (#Runtime e.Folder) = ' -D "' e.Folder '"';
+        }
+        e.Directories
+      >
+      <Map
+        {
+          (#Output e.Output) = ' "' e.Output '"';
+          (#Source (e.Source) e.Output) = ' "' e.Source '"';
+        }
+        e.Units
+      >
     >;
-}
-
-PrintNotFound {
-  (#NotFound e.UnitName) =
-    <WriteLine
-      'COMMAND LINE ERROR: Unit ' e.UnitName ' not found'
-    >;
-
-  (#Output e.Output) = ;
-  (#Source (e.Source) e.Output) = ;
-}
-
-PrintDirectory {
-  (#Search e.Folder) = '-d "' e.Folder '" ';
-
-  (#Runtime e.Folder) = '-D "' e.Folder '" ';
-}
-
-PrintUnit {
-  (#Output e.Output) = '"' e.Output '" ';
-  (#Source (e.Source) e.Output) = '"' e.Source '" ';
 }


### PR DESCRIPTION
Теперь автотесты запускаются для всех режимов компиляции: без оптимизации, с обоими оптимизациями, в режиме прямой кодогенерации и интерпретации.

Также исправлена ошибка в заготовке для оптимизации результатных выражений (она, кстати, выявлялась автотестами) + переделан разбор командной строки в нескольких утилитах.