### PR TITLE
Обновление подсветки идентификаторов вида #... для Sublime Text 3

### DIFF
--- a/editors/sublime-text-3/sref.YAML-tmLanguage
+++ b/editors/sublime-text-3/sref.YAML-tmLanguage
@@ -5,7 +5,6 @@ scopeName: source.sref
 fileTypes: [sref]
 uuid: 8d74d8c6-adaa-4888-bc0a-80ba4d340ed0
 
-
 patterns:
 - {include: '#comments'}
 - comment: keywords

--- a/editors/sublime-text-3/sref.YAML-tmLanguage
+++ b/editors/sublime-text-3/sref.YAML-tmLanguage
@@ -42,7 +42,7 @@ patterns:
 
 - comment: idents
   name: storage.type.sref
-  match: '\#\w+'
+  match: '\#[ ]*(/\*.*\*/[ ]*)?[A-Za-z0-9!?_-]+\b'
 
 - comment: block comment
   name: comment.block.documentation.sref

--- a/editors/sublime-text-3/sref.tmLanguage
+++ b/editors/sublime-text-3/sref.tmLanguage
@@ -82,7 +82,7 @@
 			<key>comment</key>
 			<string>idents</string>
 			<key>match</key>
-			<string>\#\w+</string>
+			<string>\#[ ]*(/\*.*\*/[ ]*)?[A-Za-z0-9!?_-]+\b</string>
 			<key>name</key>
 			<string>storage.type.sref</string>
 		</dict>


### PR DESCRIPTION
Удовлетворяет правилам из пункта 3.3.3 мануала (пробелы и блочный комментарий(одной строкой) между символом '#' и именем).