### PR TITLE
FIXUP: Исправлена ошибка в скрипте запуска автотестов на Windows

### DIFF
--- a/autotests/run.bat
+++ b/autotests/run.bat
@@ -6,9 +6,9 @@ goto :EOF
 setlocal
   call ..\c-plus-plus.conf.bat
   if {%1}=={} (
-    for %%s in (*.sref) do call :RUN_TEST %%s
+    for %%s in (*.sref) do call :RUN_TEST %%s || exit /b 1
   ) else (
-    for %%s in (%*) do call :RUN_TEST %%s
+    for %%s in (%*) do call :RUN_TEST %%s || exit /b 1
   )
 endlocal
 goto :EOF
@@ -16,15 +16,15 @@ goto :EOF
 :RUN_TEST
 setlocal
   set SRFLAGS=
-  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1 || exit /b 1
   set SRFLAGS=-OP
-  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1 || exit /b 1
   set SRFLAGS=-OR
-  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1 || exit /b 1
   set SRFLAGS=--gen=direct
-  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1 || exit /b 1
   set SRFLAGS=--gen=interp
-  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1
+  for %%s in (%~n1) do call :RUN_TEST_AUX%%~xs %1 || exit /b 1
 endlocal
 goto :EOF
 


### PR DESCRIPTION
Когда-то давно автотесты при обнаружении первой ошибки закрывали консоль. Я это частично исправил: консоль не закрывается, но тесты после первого фейла продолжают работать (а так можно и проглядеть ошибочный запуск).

Это исправление останавливает тесты после первой ошибки, но консоль не закрывает.